### PR TITLE
Fix order double start

### DIFF
--- a/scripts/pizza.coffee
+++ b/scripts/pizza.coffee
@@ -38,9 +38,12 @@ module.exports = (robot) ->
         ).join()
 
       start: ->
+        order = this.currentOrder()
         if this.isStarted()
-          this.closeOrder()
-        this.currentOrder().status = 'open'
+          unless order.startDate && order.startDate >= new Date(new Date() - 24 * 60 * 60 * 1000)
+            this.closeOrder()
+        order.status = 'open'
+        order.startDate = order.startDate || new Date()
 
       isStarted: ->
         this.currentOrder().status == 'open'

--- a/scripts/pizza.coffee
+++ b/scripts/pizza.coffee
@@ -39,6 +39,8 @@ module.exports = (robot) ->
         ).join()
 
       start: ->
+        if this.isStarted()
+          this.closeOrder()
         robot.brain.data.currentPizzaOrder.status = 'open'
 
       isStarted: ->


### PR DESCRIPTION
Sometimes (for various reasons) the pizza order doesn't get closed properly at the end of a Friday.

This patches at least part of this issue. It also records the first time when a pizza order is opened.

All code is untested, in particular various uses of this.currentOrder() may not work as expected.