### PR TITLE
Grouped, normalized ordering with externals

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "hubot-rules": "^0.1.1",
     "hubot-scripts": "^2.16.1",
     "hubot-shipit": "^0.2.0",
-    "hubot-slack": "^3.3.0"
+    "hubot-slack": "^3.3.0",
+    "fast-levenshtein": "^2.0.6",
+    "js-yaml": "^3.9.1"
   },
   "engines": {
     "node": "0.10.x"

--- a/scripts/pizza.coffee
+++ b/scripts/pizza.coffee
@@ -136,7 +136,10 @@ module.exports = (robot) ->
     robot.respond /pizza me (.*)/i, (msg) ->
       if pizzas.isStarted()
         sender = msg.message.user.name.toLowerCase()
-        pizza = match_pizza(msg.match[1])
+        if /special/i.test(msg.match[1])
+          pizza = msg.match[1].slice(8)
+        else
+          pizza = match_pizza(msg.match[1])
         pizzas.add(sender, pizza)
         msg.reply "One pizza #{pizza} ordered, now #{pizzas.currentQty()} on the list"
       else
@@ -146,7 +149,10 @@ module.exports = (robot) ->
     robot.respond /pizza for (\w+) (.*)/i, (msg) ->
       if pizzas.isStarted()
         external = "#{msg.message.user.name.toLowerCase()} for #{msg.match[1]}"
-        pizza = match_pizza(msg.match[2])
+        if /special/i.test(msg.match[2])
+          pizza = msg.match[2].slice(8)
+        else
+          pizza = match_pizza(msg.match[2])
         pizzas.add(external, pizza)
         msg.reply "One pizza #{pizza} ordered by #{external}, now #{pizzas.currentQty()} on the list"
       else

--- a/scripts/pizza.coffee
+++ b/scripts/pizza.coffee
@@ -38,9 +38,12 @@ module.exports = (robot) ->
         ).join()
 
       start: ->
+        order = this.currentOrder()
         if this.isStarted()
-          this.closeOrder()
-        this.currentOrder().status = 'open'
+          unless order.startDate && order.startDate >= new Date(new Date() - 24 * 60 * 60 * 1000)
+            this.closeOrder()
+        order.status = 'open'
+        order.startDate = order.startDate || new Date()
 
       isStarted: ->
         this.currentOrder().status == 'open'

--- a/scripts/pizza.coffee
+++ b/scripts/pizza.coffee
@@ -146,7 +146,7 @@ module.exports = (robot) ->
         msg.send "Sorry, no running order at this time..."
 
     ## ORDER a pizza for someone else ##
-    robot.respond /pizza for (\w+) (.*)/i, (msg) ->
+    robot.respond /pizza for (\S+) (.*)/i, (msg) ->
       if pizzas.isStarted()
         external = "#{msg.message.user.name.toLowerCase()} for #{msg.match[1]}"
         if /special/i.test(msg.match[2])
@@ -165,7 +165,7 @@ module.exports = (robot) ->
       msg.reply "Ok... I cancelled your order... pussy"
 
     ## CANCEL someone's pizza order
-    robot.respond /no pizza for (\w+)/i, (msg) ->
+    robot.respond /no pizza for (\S+)/i, (msg) ->
       external = "#{msg.message.user.name.toLowerCase()} for #{msg.match[1]}"
       pizzas.remove(external)
       msg.reply "Ok... tell #{msg.match[1]} their order is cancelled"

--- a/scripts/pizza.coffee
+++ b/scripts/pizza.coffee
@@ -39,6 +39,8 @@ module.exports = (robot) ->
         ).join()
 
       start: ->
+        if this.isStarted()
+          this.closeOrder()
         robot.brain.data.currentPizzaOrder.status = 'open'
 
       isStarted: ->

--- a/scripts/pizza.coffee
+++ b/scripts/pizza.coffee
@@ -21,8 +21,33 @@
 # Author:
 #   StijnP (XAOP)
 #
+levenshtein = require 'fast-levenshtein'
 
 module.exports = (robot) ->
+
+    pazza_menu = ['funghi', 'mano', 'rochus', 'margherita', 'carbonara', 'prosciutto', 'fratello', 'capricciosa', 'calzione', '4stagioni', 'rimini', 'vesuvio', 'vulcano', 'hawaii', 'peppina', 'napoletana', 'romana', 'extravaganza', '8gusti', 'pazza', 'boscaiola', 'montana', 'primavera', 'parmigiana', 'pollo', 'pescatore', '4formaggi', '6formaggi', 'scampis', 'bruschetta', 'toscana', 'patapizza']
+    match_pizza = (order) ->
+        # Normalization
+        replacements = [order.toLowerCase(), # Shut up
+                        [/kazen/, "formaggi"],
+                        [/fromages/, "formaggi"],
+                        [/fromaggi/, "formaggi"],
+                        [/quattro/, "4"],
+                        [/quatro/, "4"],
+                        [/sei /, "6 "],
+                        [/octo/, "8"],
+                        [/4 s/, "4s"],
+                        [/4 f/, "4f"],
+                        [/6 f/, "6f"],
+                        [/8 g/, "8g"]]
+        normalized = replacements.reduce (s, r) ->
+            s.replace r[0], r[1]
+        return normalized.split(" ").map((norm_word) ->
+            pazza_menu.map((menu_item) ->
+                [levenshtein.get(norm_word, menu_item), menu_item]
+            ).sort()[0]
+        ).sort()[0][1] # TODO optimize
+
 
     robot.brain.data.currentPizzaOrder =
       pizzas: {},

--- a/scripts/pizza.coffee
+++ b/scripts/pizza.coffee
@@ -22,31 +22,35 @@
 #   StijnP (XAOP)
 #
 levenshtein = require 'fast-levenshtein'
+yaml = require 'js-yaml'
 
 module.exports = (robot) ->
 
     pazza_menu = ['funghi', 'mano', 'rochus', 'margherita', 'carbonara', 'prosciutto', 'fratello', 'capricciosa', 'calzione', '4stagioni', 'rimini', 'vesuvio', 'vulcano', 'hawaii', 'peppina', 'napoletana', 'romana', 'extravaganza', '8gusti', 'pazza', 'boscaiola', 'montana', 'primavera', 'parmigiana', 'pollo', 'pescatore', '4formaggi', '6formaggi', 'scampis', 'bruschetta', 'toscana', 'patapizza']
     match_pizza = (order) ->
-        # Normalization
-        replacements = [order.toLowerCase(), # Shut up
-                        [/kazen/, "formaggi"],
-                        [/fromages/, "formaggi"],
-                        [/fromaggi/, "formaggi"],
-                        [/quattro/, "4"],
-                        [/quatro/, "4"],
-                        [/sei /, "6 "],
-                        [/octo/, "8"],
-                        [/4 s/, "4s"],
-                        [/4 f/, "4f"],
-                        [/6 f/, "6f"],
-                        [/8 g/, "8g"]]
-        normalized = replacements.reduce (s, r) ->
-            s.replace r[0], r[1]
-        return normalized.split(" ").map((norm_word) ->
-            pazza_menu.map((menu_item) ->
-                [levenshtein.get(norm_word, menu_item), menu_item]
-            ).sort()[0]
-        ).sort()[0][1] # TODO optimize
+      # Normalization
+      replacements = [[/seizoene(n)?/, "stagioni"],
+                      [/kaze(n)?/, "formaggi"],
+                      [/fromage(s)?/, "formaggi"],
+                      [/fromaggi(o)?/, "formaggi"],
+                      [/quat(t)?r(o|e)/, "4"],
+                      [/sei/, "6"],
+                      [/octo/, "8"],
+                      [/vier/, "4"],
+                      [/zes/, "6"],
+                      [/acht/, "8"],
+                      [/4 s/, "4s"],
+                      [/4 f/, "4f"],
+                      [/6 f/, "6f"],
+                      [/8 g/, "8g"],
+                      [/random/, pazza_menu[Math.round(Math.random()*pazza_menu.length)-1]]]
+      normalized = replacements.reduce(((s, r) -> 
+          s.replace(r[0], r[1])), order.toLowerCase())
+      return normalized.split(" ").map((norm_word) ->
+          pazza_menu.map((menu_item) ->
+              [levenshtein.get(norm_word, menu_item), menu_item]
+          ).sort()[0]
+      ).sort()[0][1]
 
     robot.brain.data.pizzaOrderHistory = robot.brain.data.pizzaOrderHistory or []
     robot.brain.data.pizzaOrderHistoryBackup = robot.brain.data.pizzaOrderHistoryBackup or []
@@ -57,9 +61,14 @@ module.exports = (robot) ->
 
       current: ->
         obj = this.currentOrder().pizzas
-        Object.keys(obj).map((key) ->
-          obj[key]
-        ).join()
+        counted = yaml.safeDump(Object.keys(obj).reduce(((p, c) ->
+          if p[obj[c]]
+            p[obj[c]] += 1
+          else
+            p[obj[c]] = 1
+          return p
+        ), {}))
+
 
       start: ->
         order = this.currentOrder()
@@ -127,11 +136,21 @@ module.exports = (robot) ->
     robot.respond /pizza me (.*)/i, (msg) ->
       if pizzas.isStarted()
         sender = msg.message.user.name.toLowerCase()
-        pizza = msg.match[1]
+        pizza = match_pizza(msg.match[1])
         pizzas.add(sender, pizza)
         msg.reply "One pizza #{pizza} ordered, now #{pizzas.currentQty()} on the list"
       else
         msg.send "Sorry, no running order at this time..."
+
+    ## ORDER a pizza for someone else ##
+    robot.respond /pizza for (\w+) (.*)/i, (msg) ->
+      if pizzas.isStarted()
+        external = "#{msg.message.user.name.toLowerCase()} for #{msg.match[1]}"
+        pizza = match_pizza(msg.match[2])
+        pizzas.add(external, pizza)
+        msg.reply "One pizza #{pizza} ordered by #{external}, now #{pizzas.currentQty()} on the list"
+      else
+        msg.send "Apologize to #{msg.match[1]} for me, no running order at this time..."
 
     ## CANCEL your pizza order
     robot.hear /no pizza for me/i, (msg) ->
@@ -139,14 +158,19 @@ module.exports = (robot) ->
       pizzas.remove(sender)
       msg.reply "Ok... I cancelled your order... pussy"
 
+    ## CANCEL someone's pizza order
+    robot.respond /no pizza for (\w+)/i, (msg) ->
+      external = "#{msg.message.user.name.toLowerCase()} for #{msg.match[1]}"
+      pizzas.remove(external)
+      msg.reply "Ok... tell #{msg.match[1]} their order is cancelled"
+
     ## SHOW CURRENT order round ##
     robot.respond /pizza (current|show)/i, (msg) ->
       qty = pizzas.currentQty()
       if qty > 0
         heroes = pizzas.currentEaters()
         names = pizzas.current()
-        msg.send "#{qty} pizzas: #{names}"
-        msg.send "Pizza heroes of today are #{heroes}"
+        msg.send "#{qty} pizzas:\n#{names}Pizza heroes of today are #{heroes}"
         # msg.send "Status is '#{robot.brain.data.currentPizzaOrder.current}'"
       else
         msg.send "No orders yet"
@@ -175,8 +199,7 @@ module.exports = (robot) ->
         names = pizzas.current()
         order = pizzas.closeOrder()
         msg.send "Pizza order CLOSED, you should now order:"
-        msg.send "#{qty} pizzas: #{names}"
-        msg.send "Pizza heroes of today are #{heroes}"
+        msg.send "#{qty} pizzas:\n#{names}Pizza heroes of today are #{heroes}"
       else
         msg.send "Nothing to close, you need to order first, silly! :pizza:"
 


### PR DESCRIPTION
This pull request includes changes made by Joeri as part of his pull request and thus makes that PR obsolete. That, for reference, fixed a bug that could cause accounting problems and did some refactoring.
This set of commits adds a matching algorithm that matches what the user typed after "pizza me" to a pizza in the Pazza menu. It is still possible to order special pizzas (without an ingredient, for example) by typing "pizza me special" and then the entire rest of that message is taken to be a pizza name. The pizzas are shown in a grouped way, for example:
rochus: 3
4formaggi: 1
bruschetta without rucola: 1
It is also possible to order for externals by typing "hubby pizza for <name> <pizza name>". This works the same as with regular ordering (including "special") but it adds an entry where the "orderer" of a pizza is "<requester> for <external>", so for example if I order a pizza for Jean-Ralphio that would show up as "joren for Jean-Ralphio" in the list. If a user adds a pizza for an external, then that user is the only user that can cancel that order.